### PR TITLE
Extending further

### DIFF
--- a/collection-hooks.js
+++ b/collection-hooks.js
@@ -265,7 +265,7 @@ CollectionHooks.wrapCollection = function wrapCollection (ns, as) {
   if (!as._CollectionConstructor) as._CollectionConstructor = as.Collection
   if (!as._CollectionPrototype) as._CollectionPrototype = new as.Collection(null)
 
-  var constructor = as._CollectionConstructor
+  var constructor = ns._NewCollectionContructor || as._CollectionConstructor
   var proto = as._CollectionPrototype
 
   ns.Collection = function () {
@@ -273,6 +273,7 @@ CollectionHooks.wrapCollection = function wrapCollection (ns, as) {
     CollectionHooks.extendCollectionInstance(this, constructor)
     return ret
   }
+  ns._NewCollectionContructor = ns.Collection
 
   ns.Collection.prototype = proto
   ns.Collection.prototype.constructor = ns.Collection
@@ -282,6 +283,8 @@ CollectionHooks.wrapCollection = function wrapCollection (ns, as) {
       ns.Collection[prop] = constructor[prop]
     }
   }
+
+  ns.Collection.apply = Function.prototype.apply;
 }
 
 CollectionHooks.modify = LocalCollection._modify

--- a/collection-hooks.js
+++ b/collection-hooks.js
@@ -273,6 +273,7 @@ CollectionHooks.wrapCollection = function wrapCollection (ns, as) {
     CollectionHooks.extendCollectionInstance(this, constructor)
     return ret
   }
+  // Retain a reference to the new constructor to allow further wrapping.
   ns._NewCollectionContructor = ns.Collection
 
   ns.Collection.prototype = proto
@@ -284,6 +285,8 @@ CollectionHooks.wrapCollection = function wrapCollection (ns, as) {
     }
   }
 
+  // Meteor overrides the apply method which is copied from the constructor in the loop above. Replace it with the
+  // default method which we need if we were to further wrap ns.Collection.
   ns.Collection.apply = Function.prototype.apply;
 }
 


### PR DESCRIPTION
I resolved an issue I was facing with using https://github.com/Sewdn/meteor-collection-behaviours. This library uses the `wrapCollection()` function a second time, which in Meteor 1.6.1 leads to discarding the extended version meteor-collection-hooks applies. My changes ensure that when creating a collection, the version in meteor-collection-behaviours will call the version in meteor-collection-hooks as well.