### PR TITLE
Fix Autoform Submit Problem

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* Resolve conflict in Insert with autoform that resulted in lost callback [#1710](https://github.com/Meteor-Community-Packages/meteor-autoform/issues/1710)
+
 ## v1.1.1
 * Added support for MongoDB 5.x => insertOne instead of insert [PR](https://github.com/Meteor-Community-Packages/meteor-collection-hooks/pull/278) [@KoenLav](https://github.com/KoenLav)
 * Updated dev dependencies

--- a/insert.js
+++ b/insert.js
@@ -10,7 +10,7 @@ CollectionHooks.defineAdvice('insert', function (userId, _super, instance, aspec
     callback = args[args.length - 1]
   }
   
-const async = typeof callback === 'function'
+  const async = typeof callback === 'function'
   let abort
   let ret
 

--- a/insert.js
+++ b/insert.js
@@ -4,8 +4,13 @@ import { CollectionHooks } from './collection-hooks'
 
 CollectionHooks.defineAdvice('insert', function (userId, _super, instance, aspects, getTransform, args, suppressAspects) {
   const ctx = { context: this, _super, args }
-  let [doc, callback] = args
-  const async = typeof callback === 'function'
+  let doc = args[0]
+  let callback
+  if (typeof args[args.length -1] === 'function')  {
+    callback = args[args.length - 1]
+  }
+  
+const async = typeof callback === 'function'
   let abort
   let ret
 


### PR DESCRIPTION
Fixes problem with callbacks being lost because args passed from autoform include a validation object while collection-hooks assumes only two args.