### PR TITLE
Fix change in default behavior for getDocs

### DIFF
--- a/collection-hooks.js
+++ b/collection-hooks.js
@@ -141,7 +141,7 @@ CollectionHooks.extendOptions = (source, options, pointcut, method) =>
   ({ ...options, ...source.all.all, ...source[pointcut].all, ...source.all[method], ...source[pointcut][method] })
 
 CollectionHooks.getDocs = function getDocs (collection, selector, options, fetchFields) {
-  const findOptions = { transform: null, reactive: false, fields: fetchFields || {} } // added reactive: false
+  const findOptions = { transform: null, reactive: false, fields: fetchFields || false } // added reactive: false
 
   /*
   // No "fetch" support at this time.


### PR DESCRIPTION
Before https://github.com/Meteor-Community-Packages/meteor-collection-hooks/pull/256 getDocs would return all fields of a document by default.

This commit restores the previous behavior.