### PR TITLE
Fix loop in before.find when retuning false

### DIFF
--- a/find.js
+++ b/find.js
@@ -12,7 +12,7 @@ CollectionHooks.defineAdvice('find', function (userId, _super, instance, aspects
       if (r === false) abort = true
     })
 
-    if (abort) return instance.find(undefined)
+    if (abort) return instance.direct.find(undefined)
   }
 
   const after = (cursor) => {


### PR DESCRIPTION
Fix loop when returning `false` from before.find.

You would get in a loop because this code would do a .find(undefined), which would again execute the before.find.