### PR TITLE
Fix publish wrapper on meteor 3.0

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,10 +28,10 @@ CollectionHooks.getUserId = function getUserId () {
 
 const _publish = Meteor.publish
 Meteor.publish = function (name, handler, options) {
-  return _publish.call(this, name, function (...args) {
+  return publishUserId.withValue(this && this.userId, () => _publish.call(this, name, function (...args) {
     // This function is called repeatedly in publications
-    return publishUserId.withValue(this && this.userId, () => handler.apply(this, args))
-  }, options)
+    return handler.apply(this, args)
+  }, options))
 }
 
 // Make the above available for packages with hooks that want to determine


### PR DESCRIPTION
This PR refers to the issue https://github.com/Meteor-Community-Packages/meteor-collection-hooks/issues/314 and refered to the core at https://github.com/meteor/meteor/issues/13258.

The fix involves using `EnvironmentVariable.withValue` before calling `publish.call`. This ensures the context is preserved and spread properly throughout the entire flow of an altered publication. This was a breaking change on Meteor 3 added on this change, https://github.com/meteor/meteor/pull/13063.

All tests pass ok. Not sure if meteor-collection-hooks is fully compatible for 3.0 already, but this change needs to be published when the new/next version is out.

![image](https://github.com/user-attachments/assets/6b1d6649-5334-45b2-973e-5aad36713d3b)
