### PR TITLE
Migrate/3.0 - fix: proposal to keep before.find operations sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ test.before.find(function (userId, selector, options) {
 });
 ```
 
-__Important:__ This hook does not get called for `after.update` hooks (see https://github.com/Meteor-Community-Packages/meteor-collection-hooks/pull/297).
+__Important:__ 
+- The function used as `before.find` hook cannot be async
+- This hook does not get called for `after.update` hooks (see https://github.com/Meteor-Community-Packages/meteor-collection-hooks/pull/297).
 
 --------------------------------------------------------------------------------
 

--- a/find.js
+++ b/find.js
@@ -17,6 +17,8 @@ CollectionHooks.defineWrapper('find', function (userId, _super, instance, hooks,
   hooks.before.forEach(hook => {
     if (!hook.hook.constructor.name.includes('Async')) {
       hook.hook.call(this, userId, selector, options)
+    } else {
+      throw new Error('Cannot use async function as before.find hook')
     }
   })
 
@@ -27,13 +29,7 @@ CollectionHooks.defineWrapper('find', function (userId, _super, instance, hooks,
     if (cursor[method]) {
       const originalMethod = cursor[method]
       cursor[method] = async function (...args) {
-        // Apply asynchronous before hooks
-        for (const hook of hooks.before) {
-          if (hook.hook.constructor.name.includes('Async')) {
-            await hook.hook.call(this, userId, selector, options)
-          }
-        }
-
+        // Do not try to apply asynchronous before hooks here because they act on the cursor which is already defined
         const result = await originalMethod.apply(this, args)
 
         // Apply after hooks

--- a/tests/find.js
+++ b/tests/find.js
@@ -6,8 +6,9 @@ Tinytest.addAsync('find - selector should be {} when called without arguments', 
   const collection = new Mongo.Collection(null)
 
   let findSelector = null
-  collection.before.find(async function (userId, selector, options) {
+  collection.before.find(function (userId, selector, options) {
     findSelector = selector
+    return true
   })
 
   // hooks won't be triggered on find() alone, we must call fetchAsync()

--- a/tests/find_after_hooks.js
+++ b/tests/find_after_hooks.js
@@ -53,7 +53,7 @@ Tinytest.addAsync('issue #296 - after insert hook always finds all inserted', as
   test.equal(afterCalled, true)
 })
 
-Tinytest.addAsync('async find hook - after insert hook always finds all inserted', async function (test, next) {
+Tinytest.addAsync('find hook - after insert hook always finds all inserted', async function (test, next) {
   const collection = new Mongo.Collection(null)
 
   collection.before.find((userId, selector) => {


### PR DESCRIPTION
There is still a failing test on [PR for the Async migration](https://github.com/Meteor-Community-Packages/meteor-collection-hooks/pull/306) when using an Async function inside `before.find` hook ([this test](https://github.com/Meteor-Community-Packages/meteor-collection-hooks/blob/57616712ae5fbc0451513a4b98f4be29f78df52b/tests/find_after_hooks.js#L59)) 

This issue source lies [here](https://github.com/Meteor-Community-Packages/meteor-collection-hooks/blob/57616712ae5fbc0451513a4b98f4be29f78df52b/find.js#L18) where Async case is not handled. 

I propose to update the code to throw an Exception

Due to the nature of `before.find` operations which modify a cursor before applying an Async method (fetchAsync, countAsync, ...), this seems the easiest way to fix the package and test suite and I don't see the limitation of not being able to use Async operation on before.find (which is mainly used to modify the selectors to implement soft deletion) as a huge drawback.